### PR TITLE
java.net.UrlHTTPConnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@
 .idea/*
 *.iml
 
+# compiled artifacts
+test/**/.*.java
+
 # compiled
 *.class

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # jetbrains shenanigans
 .idea/*
 *.iml
+
+# compiled
+*.class

--- a/test/java/java.net/Test.java
+++ b/test/java/java.net/Test.java
@@ -1,8 +1,10 @@
+package com.test;
+
 import java.io.*;
 import java.lang.reflect.Array;
 import java.net.*;
 
-public class Test {
+public class HttpTest {
     public static String getHTML(String urlToRead) throws Exception {
         StringBuilder result = new StringBuilder();
         URL url = new URL(urlToRead);
@@ -14,6 +16,16 @@ public class Test {
             result.append(line);
         }
         rd.close();
+
+        if (url.toString().matches(".*numbers$")) {
+            if (result.toString().isEmpty()) { // TODO match on the response code being \d+
+                System.err.println("java.net/HttpURLConnection is conflating response code and body, but in a particularly stange way"); // nice consistency on the class casing..
+                System.err.println("request url[" + url.toString() + "]");
+                System.err.println("response body[" + result.toString() + "]");
+                System.err.println("response code[" + conn.getResponseCode() + "]");
+                System.exit(1);
+            }
+        }
         return result.toString();
     }
 

--- a/test/java/java.net/Test.java
+++ b/test/java/java.net/Test.java
@@ -21,6 +21,16 @@ public class Test {
     {
         String meta = getHTML("http://localhost:4567/meta");
         System.out.println(meta);
+
+        // split on , strip quotes and iterate
+        String[] results = meta.split(",");
+
+        for (String result : results) {
+            String lresult  = result.toString().replaceAll("\\[", "").replaceAll("\\]", "").replaceAll("\"", "");
+            String response = getHTML(lresult);
+            System.out.println("url:[" + lresult + "] response[" + response + "]");
+        }
+
     }
 
 }

--- a/test/java/java.net/Test.java
+++ b/test/java/java.net/Test.java
@@ -1,0 +1,26 @@
+import java.io.*;
+import java.lang.reflect.Array;
+import java.net.*;
+
+public class Test {
+    public static String getHTML(String urlToRead) throws Exception {
+        StringBuilder result = new StringBuilder();
+        URL url = new URL(urlToRead);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        BufferedReader rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        String line;
+        while ((line = rd.readLine()) != null) {
+            result.append(line);
+        }
+        rd.close();
+        return result.toString();
+    }
+
+    public static void main(String[] args) throws Exception
+    {
+        String meta = getHTML("http://localhost:4567/meta");
+        System.out.println(meta);
+    }
+
+}

--- a/test/java/java.net/test.sh
+++ b/test/java/java.net/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# dependencies check
+if [ -z `which java` ]; then
+  echo "ERROR: unable to find 'java' in \$PATH, skipping"
+  exit 0
+fi
+
+# definition
+DIR=`dirname $0`
+TEST="${DIR}/Test.java"
+
+# compilation
+echo "compiling [${TEST}]"
+javac ${TEST}
+
+# execution
+echo "running [${TEST}]"
+cd ${DIR}
+java Test


### PR DESCRIPTION
- adding .gitignore entries for compiled artifacts
- initial implementation of java.net.UrlHTTPConnection tests
  - it is not catching the problem that numbers < 200 cannot be HTTP response codes, and confusing the body for the status -- which is the clearest understanding of the source of this problem so far
- test.sh to compile and run tests
